### PR TITLE
MANIFEST.SKIP: skip MYMETA.*

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -2,6 +2,7 @@
 \bCVS\b
 ^MANIFEST\.
 ^Makefile$
+^MYMETA\.
 ~$
 \.old$
 ^blib/


### PR DESCRIPTION
MYMETA.\* are generated during install. They must not be bundled in the distribution.
http://cpants.cpanauthors.org/kwalitee/no_mymeta_files
