### PR TITLE
Update picohttpparser f8d0513

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,63 +9,35 @@ on:
   pull_request:
 
 jobs:
-  ubuntu:
-    name: ubuntu perl ${{ matrix.perl-version }}
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
-        perl-version:
-          - '5.10-buster'
-          - '5.12-buster'
-          - '5.14-buster'
-          - '5.16-buster'
-          - '5.18-buster'
-          - '5.20-buster'
-          - '5.22-buster'
-          - '5.24-buster'
-          - '5.26-buster'
-          - '5.28-buster'
-          - '5.30-buster'
-          - '5.32-buster'
-          - '5.34-buster'
-          - '5.36-buster'
-          - '5.38-buster'
-          - 'latest'
-    container:
-      image: perl:${{ matrix.perl-version }}
+        os: ["ubuntu-latest", "macos-latest"]
+        perl:
+          - '5.14'
+          - '5.16'
+          - '5.18'
+          - '5.20'
+          - '5.22'
+          - '5.24'
+          - '5.26'
+          - '5.28'
+          - '5.30'
+          - '5.32'
+          - '5.34'
+          - '5.36'
+          - '5.38'
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: perl -V
-        run: perl -V
-      - name: Install Dependencies
-        run: curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g --with-configure --show-build-log-on-failure
-      - name: Run Makefile.PL
-        run: perl Makefile.PL
-      - name: Run Make
-        run: make
-      - name: Run Tests
-        run: make test
-  macos:
-    name: macos ${{ matrix.perl }}
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - perl: /usr/bin/perl
-            cpm-option: --sudo
-          - perl: /usr/local/bin/perl
-            cpm-option: ''
-    steps:
-      - uses: actions/checkout@v4
-      - name: perl -V
-        run: ${{ matrix.perl }} -V
-      - name: Install Dependencies
-        run: curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | ${{ matrix.perl }} - install -g ${{ matrix.cpm-option }} --with-configure --show-build-log-on-failure
-      - name: Run Makefile.PL
-        run: ${{ matrix.perl }} Makefile.PL
-      - name: Run Make
-        run: make
-      - name: Run Tests
-        run: make test
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+          install-modules-with: cpanm
+          install-modules-args: --with-develop --with-configure
+      - run: perl -V
+      - run: perl -Ilocal/lib/perl5 Makefile.PL
+      - run: make
+      - run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: test
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  ubuntu:
+    name: ubuntu perl ${{ matrix.perl-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - '5.10-buster'
+          - '5.12-buster'
+          - '5.14-buster'
+          - '5.16-buster'
+          - '5.18-buster'
+          - '5.20-buster'
+          - '5.22-buster'
+          - '5.24-buster'
+          - '5.26-buster'
+          - '5.28-buster'
+          - '5.30-buster'
+          - '5.32-buster'
+          - '5.34-buster'
+          - '5.36-buster'
+          - '5.38-buster'
+          - 'latest'
+    container:
+      image: perl:${{ matrix.perl-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g --with-configure --show-build-log-on-failure
+      - name: Run Makefile.PL
+        run: perl Makefile.PL
+      - name: Run Make
+        run: make
+      - name: Run Tests
+        run: make test
+  macos:
+    name: macos ${{ matrix.perl }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - perl: /usr/bin/perl
+            cpm-option: --sudo
+          - perl: /usr/local/bin/perl
+            cpm-option: ''
+    steps:
+      - uses: actions/checkout@v4
+      - name: perl -V
+        run: ${{ matrix.perl }} -V
+      - name: Install Dependencies
+        run: curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | ${{ matrix.perl }} - install -g ${{ matrix.cpm-option }} --with-configure --show-build-log-on-failure
+      - name: Run Makefile.PL
+        run: ${{ matrix.perl }} Makefile.PL
+      - name: Run Make
+        run: make
+      - name: Run Tests
+        run: make test

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,8 @@
+on configure => sub {
+    requires 'Module::Install';
+    requires 'Module::Install::TestTarget';
+    requires 'Module::Install::ReadmeFromPod';
+};
+on test => sub {
+    requires 'Test::More' => '0.96';
+};

--- a/picohttpparser/picohttpparser.c
+++ b/picohttpparser/picohttpparser.c
@@ -1,341 +1,683 @@
+/*
+ * Copyright (c) 2009-2014 Kazuho Oku, Tokuhiro Matsuno, Daisuke Murase,
+ *                         Shigeo Mitsunari
+ *
+ * The software is licensed under either the MIT License (below) or the Perl
+ * license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <assert.h>
 #include <stddef.h>
+#include <string.h>
+#ifdef __SSE4_2__
+#ifdef _MSC_VER
+#include <nmmintrin.h>
+#else
+#include <x86intrin.h>
+#endif
+#endif
 #include "picohttpparser.h"
 
-/* $Id: f88e09222873f8bd56c7836037b3fd0047024023 $ */
-
 #if __GNUC__ >= 3
-# define likely(x)	__builtin_expect(!!(x), 1)
-# define unlikely(x)	__builtin_expect(!!(x), 0)
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
 #else
-# define likely(x) (x)
-# define unlikely(x) (x)
+#define likely(x) (x)
+#define unlikely(x) (x)
 #endif
 
-#define CHECK_EOF()	\
-  if (buf == buf_end) {	\
-    *ret = -2;		\
-    return NULL;	\
-  }
+#ifdef _MSC_VER
+#define ALIGNED(n) _declspec(align(n))
+#else
+#define ALIGNED(n) __attribute__((aligned(n)))
+#endif
 
-#define EXPECT_CHAR(ch) \
-  CHECK_EOF();		\
-  if (*buf++ != ch) {	\
-    *ret = -1;		\
-    return NULL;	\
-  }
+#define IS_PRINTABLE_ASCII(c) ((unsigned char)(c)-040u < 0137u)
 
-#define ADVANCE_TOKEN(tok, toklen) do {		       \
-    const char* tok_start = buf; 		       \
-    for (; ; ++buf) {				       \
-      CHECK_EOF();				       \
-      if (*buf == ' ') {			       \
-	break;					       \
-      } else if (*buf == '\015' || *buf == '\012') {   \
-	*ret = -1;				       \
-	return NULL;				       \
-      }						       \
-    }						       \
-    tok = tok_start;				       \
-    toklen = buf - tok_start;			       \
-  } while (0)
+#define CHECK_EOF()                                                                                                                \
+    if (buf == buf_end) {                                                                                                          \
+        *ret = -2;                                                                                                                 \
+        return NULL;                                                                                                               \
+    }
 
-static const char* token_char_map =
-  "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-  "\0\1\1\1\1\1\1\1\0\0\1\1\0\1\1\0\1\1\1\1\1\1\1\1\1\1\0\0\0\0\0\0"
-  "\0\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\0\0\1\1"
-  "\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\1\0\1\0"
-  "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-  "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-  "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-  "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+#define EXPECT_CHAR_NO_CHECK(ch)                                                                                                   \
+    if (*buf++ != ch) {                                                                                                            \
+        *ret = -1;                                                                                                                 \
+        return NULL;                                                                                                               \
+    }
 
-static const char* get_token_to_eol(const char* buf, const char* buf_end,
-				    const char** token, size_t* token_len,
-				    int* ret)
+#define EXPECT_CHAR(ch)                                                                                                            \
+    CHECK_EOF();                                                                                                                   \
+    EXPECT_CHAR_NO_CHECK(ch);
+
+#define ADVANCE_TOKEN(tok, toklen)                                                                                                 \
+    do {                                                                                                                           \
+        const char *tok_start = buf;                                                                                               \
+        static const char ALIGNED(16) ranges2[16] = "\000\040\177\177";                                                            \
+        int found2;                                                                                                                \
+        buf = findchar_fast(buf, buf_end, ranges2, 4, &found2);                                                                    \
+        if (!found2) {                                                                                                             \
+            CHECK_EOF();                                                                                                           \
+        }                                                                                                                          \
+        while (1) {                                                                                                                \
+            if (*buf == ' ') {                                                                                                     \
+                break;                                                                                                             \
+            } else if (unlikely(!IS_PRINTABLE_ASCII(*buf))) {                                                                      \
+                if ((unsigned char)*buf < '\040' || *buf == '\177') {                                                              \
+                    *ret = -1;                                                                                                     \
+                    return NULL;                                                                                                   \
+                }                                                                                                                  \
+            }                                                                                                                      \
+            ++buf;                                                                                                                 \
+            CHECK_EOF();                                                                                                           \
+        }                                                                                                                          \
+        tok = tok_start;                                                                                                           \
+        toklen = buf - tok_start;                                                                                                  \
+    } while (0)
+
+static const char *token_char_map = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\1\0\1\1\1\1\1\0\0\1\1\0\1\1\0\1\1\1\1\1\1\1\1\1\1\0\0\0\0\0\0"
+                                    "\0\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\0\0\1\1"
+                                    "\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\1\0\1\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+static const char *findchar_fast(const char *buf, const char *buf_end, const char *ranges, size_t ranges_size, int *found)
 {
-  const char* token_start = buf;
-  
-  while (1) {
+    *found = 0;
+#if __SSE4_2__
     if (likely(buf_end - buf >= 16)) {
-      unsigned i;
-      for (i = 0; i < 16; i++, ++buf) {
-	if (unlikely((unsigned char)*buf <= '\015')
-	    && (*buf == '\015' || *buf == '\012')) {
-	  goto EOL_FOUND;
-	}
-      }
-    } else {
-      for (; ; ++buf) {
-	CHECK_EOF();
-	if (unlikely((unsigned char)*buf <= '\015')
-	    && (*buf == '\015' || *buf == '\012')) {
-	  goto EOL_FOUND;
-	}
-      }
+        __m128i ranges16 = _mm_loadu_si128((const __m128i *)ranges);
+
+        size_t left = (buf_end - buf) & ~15;
+        do {
+            __m128i b16 = _mm_loadu_si128((const __m128i *)buf);
+            int r = _mm_cmpestri(ranges16, ranges_size, b16, 16, _SIDD_LEAST_SIGNIFICANT | _SIDD_CMP_RANGES | _SIDD_UBYTE_OPS);
+            if (unlikely(r != 16)) {
+                buf += r;
+                *found = 1;
+                break;
+            }
+            buf += 16;
+            left -= 16;
+        } while (likely(left != 0));
     }
-  }
- EOL_FOUND:
-  if (*buf == '\015') {
-    ++buf;
-    EXPECT_CHAR('\012');
-    *token_len = buf - 2 - token_start;
-  } else { /* should be: *buf == '\012' */
-    *token_len = buf - token_start;
-    ++buf;
-  }
-  *token = token_start;
-  
-  return buf;
-}
-  
-static const char* is_complete(const char* buf, const char* buf_end,
-			       size_t last_len, int* ret)
-{
-  int ret_cnt = 0;
-  buf = last_len < 3 ? buf : buf + last_len - 3;
-  
-  while (1) {
-    CHECK_EOF();
-    if (*buf == '\015') {
-      ++buf;
-      CHECK_EOF();
-      EXPECT_CHAR('\012');
-      ++ret_cnt;
-    } else if (*buf == '\012') {
-      ++buf;
-      ++ret_cnt;
-    } else {
-      ++buf;
-      ret_cnt = 0;
-    }
-    if (ret_cnt == 2) {
-      return buf;
-    }
-  }
-  
-  *ret = -2;
-  return NULL;
+#else
+    /* suppress unused parameter warning */
+    (void)buf_end;
+    (void)ranges;
+    (void)ranges_size;
+#endif
+    return buf;
 }
 
-/* *_buf is always within [buf, buf_end) upon success */
-static const char* parse_int(const char* buf, const char* buf_end, int* value,
-			     int* ret)
+static const char *get_token_to_eol(const char *buf, const char *buf_end, const char **token, size_t *token_len, int *ret)
 {
-  int v;
-  CHECK_EOF();
-  if (! ('0' <= *buf && *buf <= '9')) {
-    *ret = -1;
-    return NULL;
-  }
-  v = 0;
-  for (; ; ++buf) {
-    CHECK_EOF();
-    if ('0' <= *buf && *buf <= '9') {
-      v = v * 10 + *buf - '0';
-    } else {
-      break;
+    const char *token_start = buf;
+
+#ifdef __SSE4_2__
+    static const char ALIGNED(16) ranges1[16] = "\0\010"    /* allow HT */
+                                                "\012\037"  /* allow SP and up to but not including DEL */
+                                                "\177\177"; /* allow chars w. MSB set */
+    int found;
+    buf = findchar_fast(buf, buf_end, ranges1, 6, &found);
+    if (found)
+        goto FOUND_CTL;
+#else
+    /* find non-printable char within the next 8 bytes, this is the hottest code; manually inlined */
+    while (likely(buf_end - buf >= 8)) {
+#define DOIT()                                                                                                                     \
+    do {                                                                                                                           \
+        if (unlikely(!IS_PRINTABLE_ASCII(*buf)))                                                                                   \
+            goto NonPrintable;                                                                                                     \
+        ++buf;                                                                                                                     \
+    } while (0)
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+#undef DOIT
+        continue;
+    NonPrintable:
+        if ((likely((unsigned char)*buf < '\040') && likely(*buf != '\011')) || unlikely(*buf == '\177')) {
+            goto FOUND_CTL;
+        }
+        ++buf;
     }
-  }
-  
-  *value = v;
-  return buf;
+#endif
+    for (;; ++buf) {
+        CHECK_EOF();
+        if (unlikely(!IS_PRINTABLE_ASCII(*buf))) {
+            if ((likely((unsigned char)*buf < '\040') && likely(*buf != '\011')) || unlikely(*buf == '\177')) {
+                goto FOUND_CTL;
+            }
+        }
+    }
+FOUND_CTL:
+    if (likely(*buf == '\015')) {
+        ++buf;
+        EXPECT_CHAR('\012');
+        *token_len = buf - 2 - token_start;
+    } else if (*buf == '\012') {
+        *token_len = buf - token_start;
+        ++buf;
+    } else {
+        *ret = -1;
+        return NULL;
+    }
+    *token = token_start;
+
+    return buf;
+}
+
+static const char *is_complete(const char *buf, const char *buf_end, size_t last_len, int *ret)
+{
+    int ret_cnt = 0;
+    buf = last_len < 3 ? buf : buf + last_len - 3;
+
+    while (1) {
+        CHECK_EOF();
+        if (*buf == '\015') {
+            ++buf;
+            CHECK_EOF();
+            EXPECT_CHAR('\012');
+            ++ret_cnt;
+        } else if (*buf == '\012') {
+            ++buf;
+            ++ret_cnt;
+        } else {
+            ++buf;
+            ret_cnt = 0;
+        }
+        if (ret_cnt == 2) {
+            return buf;
+        }
+    }
+
+    *ret = -2;
+    return NULL;
+}
+
+#define PARSE_INT(valp_, mul_)                                                                                                     \
+    if (*buf < '0' || '9' < *buf) {                                                                                                \
+        buf++;                                                                                                                     \
+        *ret = -1;                                                                                                                 \
+        return NULL;                                                                                                               \
+    }                                                                                                                              \
+    *(valp_) = (mul_) * (*buf++ - '0');
+
+#define PARSE_INT_3(valp_)                                                                                                         \
+    do {                                                                                                                           \
+        int res_ = 0;                                                                                                              \
+        PARSE_INT(&res_, 100)                                                                                                      \
+        *valp_ = res_;                                                                                                             \
+        PARSE_INT(&res_, 10)                                                                                                       \
+        *valp_ += res_;                                                                                                            \
+        PARSE_INT(&res_, 1)                                                                                                        \
+        *valp_ += res_;                                                                                                            \
+    } while (0)
+
+/* returned pointer is always within [buf, buf_end), or null */
+static const char *parse_token(const char *buf, const char *buf_end, const char **token, size_t *token_len, char next_char,
+                               int *ret)
+{
+    /* We use pcmpestri to detect non-token characters. This instruction can take no more than eight character ranges (8*2*8=128
+     * bits that is the size of a SSE register). Due to this restriction, characters `|` and `~` are handled in the slow loop. */
+    static const char ALIGNED(16) ranges[] = "\x00 "  /* control chars and up to SP */
+                                             "\"\""   /* 0x22 */
+                                             "()"     /* 0x28,0x29 */
+                                             ",,"     /* 0x2c */
+                                             "//"     /* 0x2f */
+                                             ":@"     /* 0x3a-0x40 */
+                                             "[]"     /* 0x5b-0x5d */
+                                             "{\xff"; /* 0x7b-0xff */
+    const char *buf_start = buf;
+    int found;
+    buf = findchar_fast(buf, buf_end, ranges, sizeof(ranges) - 1, &found);
+    if (!found) {
+        CHECK_EOF();
+    }
+    while (1) {
+        if (*buf == next_char) {
+            break;
+        } else if (!token_char_map[(unsigned char)*buf]) {
+            *ret = -1;
+            return NULL;
+        }
+        ++buf;
+        CHECK_EOF();
+    }
+    *token = buf_start;
+    *token_len = buf - buf_start;
+    return buf;
 }
 
 /* returned pointer is always within [buf, buf_end), or null */
-static const char* parse_http_version(const char* buf, const char* buf_end,
-				      int* minor_version, int* ret)
+static const char *parse_http_version(const char *buf, const char *buf_end, int *minor_version, int *ret)
 {
-  EXPECT_CHAR('H'); EXPECT_CHAR('T'); EXPECT_CHAR('T'); EXPECT_CHAR('P');
-  EXPECT_CHAR('/'); EXPECT_CHAR('1'); EXPECT_CHAR('.');
-  return parse_int(buf, buf_end, minor_version, ret);
+    /* we want at least [HTTP/1.<two chars>] to try to parse */
+    if (buf_end - buf < 9) {
+        *ret = -2;
+        return NULL;
+    }
+    EXPECT_CHAR_NO_CHECK('H');
+    EXPECT_CHAR_NO_CHECK('T');
+    EXPECT_CHAR_NO_CHECK('T');
+    EXPECT_CHAR_NO_CHECK('P');
+    EXPECT_CHAR_NO_CHECK('/');
+    EXPECT_CHAR_NO_CHECK('1');
+    EXPECT_CHAR_NO_CHECK('.');
+    PARSE_INT(minor_version, 1);
+    return buf;
 }
 
-static const char* parse_headers(const char* buf, const char* buf_end,
-				 struct phr_header* headers,
-				 size_t* num_headers, size_t max_headers,
-				 int* ret)
+static const char *parse_headers(const char *buf, const char *buf_end, struct phr_header *headers, size_t *num_headers,
+                                 size_t max_headers, int *ret)
 {
-  for (; ; ++*num_headers) {
+    for (;; ++*num_headers) {
+        CHECK_EOF();
+        if (*buf == '\015') {
+            ++buf;
+            EXPECT_CHAR('\012');
+            break;
+        } else if (*buf == '\012') {
+            ++buf;
+            break;
+        }
+        if (*num_headers == max_headers) {
+            *ret = -1;
+            return NULL;
+        }
+        if (!(*num_headers != 0 && (*buf == ' ' || *buf == '\t'))) {
+            /* parsing name, but do not discard SP before colon, see
+             * http://www.mozilla.org/security/announce/2006/mfsa2006-33.html */
+            if ((buf = parse_token(buf, buf_end, &headers[*num_headers].name, &headers[*num_headers].name_len, ':', ret)) == NULL) {
+                return NULL;
+            }
+            if (headers[*num_headers].name_len == 0) {
+                *ret = -1;
+                return NULL;
+            }
+            ++buf;
+            for (;; ++buf) {
+                CHECK_EOF();
+                if (!(*buf == ' ' || *buf == '\t')) {
+                    break;
+                }
+            }
+        } else {
+            headers[*num_headers].name = NULL;
+            headers[*num_headers].name_len = 0;
+        }
+        const char *value;
+        size_t value_len;
+        if ((buf = get_token_to_eol(buf, buf_end, &value, &value_len, ret)) == NULL) {
+            return NULL;
+        }
+        /* remove trailing SPs and HTABs */
+        const char *value_end = value + value_len;
+        for (; value_end != value; --value_end) {
+            const char c = *(value_end - 1);
+            if (!(c == ' ' || c == '\t')) {
+                break;
+            }
+        }
+        headers[*num_headers].value = value;
+        headers[*num_headers].value_len = value_end - value;
+    }
+    return buf;
+}
+
+static const char *parse_request(const char *buf, const char *buf_end, const char **method, size_t *method_len, const char **path,
+                                 size_t *path_len, int *minor_version, struct phr_header *headers, size_t *num_headers,
+                                 size_t max_headers, int *ret)
+{
+    /* skip first empty line (some clients add CRLF after POST content) */
     CHECK_EOF();
     if (*buf == '\015') {
-      ++buf;
-      EXPECT_CHAR('\012');
-      break;
+        ++buf;
+        EXPECT_CHAR('\012');
     } else if (*buf == '\012') {
-      ++buf;
-      break;
+        ++buf;
     }
-    if (*num_headers == max_headers) {
-      *ret = -1;
-      return NULL;
+
+    /* parse request line */
+    if ((buf = parse_token(buf, buf_end, method, method_len, ' ', ret)) == NULL) {
+        return NULL;
     }
-    if (! (*num_headers != 0 && (*buf == ' ' || *buf == '\t'))) {
-      if (! token_char_map[(unsigned char)*buf]) {
-	*ret = -1;
-	return NULL;
-      }
-      /* parsing name, but do not discard SP before colon, see
-       * http://www.mozilla.org/security/announce/2006/mfsa2006-33.html */
-      headers[*num_headers].name = buf;
-      for (; ; ++buf) {
-	CHECK_EOF();
-	if (*buf == ':') {
-	  break;
-	} else if (*buf < ' ') {
-	  *ret = -1;
-	  return NULL;
-	}
-      }
-      headers[*num_headers].name_len = buf - headers[*num_headers].name;
-      ++buf;
-      for (; ; ++buf) {
-	CHECK_EOF();
-	if (! (*buf == ' ' || *buf == '\t')) {
-	  break;
-	}
-      }
+    do {
+        ++buf;
+        CHECK_EOF();
+    } while (*buf == ' ');
+    ADVANCE_TOKEN(*path, *path_len);
+    do {
+        ++buf;
+        CHECK_EOF();
+    } while (*buf == ' ');
+    if (*method_len == 0 || *path_len == 0) {
+        *ret = -1;
+        return NULL;
+    }
+    if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
+        return NULL;
+    }
+    if (*buf == '\015') {
+        ++buf;
+        EXPECT_CHAR('\012');
+    } else if (*buf == '\012') {
+        ++buf;
     } else {
-      headers[*num_headers].name = NULL;
-      headers[*num_headers].name_len = 0;
+        *ret = -1;
+        return NULL;
     }
-    if ((buf = get_token_to_eol(buf, buf_end, &headers[*num_headers].value,
-				&headers[*num_headers].value_len, ret))
-	== NULL) {
-      return NULL;
+
+    return parse_headers(buf, buf_end, headers, num_headers, max_headers, ret);
+}
+
+int phr_parse_request(const char *buf_start, size_t len, const char **method, size_t *method_len, const char **path,
+                      size_t *path_len, int *minor_version, struct phr_header *headers, size_t *num_headers, size_t last_len)
+{
+    const char *buf = buf_start, *buf_end = buf_start + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *method = NULL;
+    *method_len = 0;
+    *path = NULL;
+    *path_len = 0;
+    *minor_version = -1;
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the request is complete (a fast countermeasure
+       againt slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
     }
-  }
-  return buf;
+
+    if ((buf = parse_request(buf, buf_end, method, method_len, path, path_len, minor_version, headers, num_headers, max_headers,
+                             &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
 }
 
-const char* parse_request(const char* buf, const char* buf_end,
-			  const char** method, size_t* method_len,
-			  const char** path, size_t* path_len,
-			  int* minor_version, struct phr_header* headers,
-			  size_t* num_headers, size_t max_headers, int* ret)
+static const char *parse_response(const char *buf, const char *buf_end, int *minor_version, int *status, const char **msg,
+                                  size_t *msg_len, struct phr_header *headers, size_t *num_headers, size_t max_headers, int *ret)
 {
-  /* skip first empty line (some clients add CRLF after POST content) */
-  CHECK_EOF();
-  if (*buf == '\015') {
-    ++buf;
-    EXPECT_CHAR('\012');
-  } else if (*buf == '\012') {
-    ++buf;
-  }
-  
-  /* parse request line */
-  ADVANCE_TOKEN(*method, *method_len);
-  ++buf;
-  ADVANCE_TOKEN(*path, *path_len);
-  ++buf;
-  if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
-    return NULL;
-  }
-  if (*buf == '\015') {
-    ++buf;
-    EXPECT_CHAR('\012');
-  } else if (*buf == '\012') {
-    ++buf;
-  } else {
-    *ret = -1;
-    return NULL;
-  }
-  
-  return parse_headers(buf, buf_end, headers, num_headers, max_headers, ret);
+    /* parse "HTTP/1.x" */
+    if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
+        return NULL;
+    }
+    /* skip space */
+    if (*buf != ' ') {
+        *ret = -1;
+        return NULL;
+    }
+    do {
+        ++buf;
+        CHECK_EOF();
+    } while (*buf == ' ');
+    /* parse status code, we want at least [:digit:][:digit:][:digit:]<other char> to try to parse */
+    if (buf_end - buf < 4) {
+        *ret = -2;
+        return NULL;
+    }
+    PARSE_INT_3(status);
+
+    /* get message including preceding space */
+    if ((buf = get_token_to_eol(buf, buf_end, msg, msg_len, ret)) == NULL) {
+        return NULL;
+    }
+    if (*msg_len == 0) {
+        /* ok */
+    } else if (**msg == ' ') {
+        /* Remove preceding space. Successful return from `get_token_to_eol` guarantees that we would hit something other than SP
+         * before running past the end of the given buffer. */
+        do {
+            ++*msg;
+            --*msg_len;
+        } while (**msg == ' ');
+    } else {
+        /* garbage found after status code */
+        *ret = -1;
+        return NULL;
+    }
+
+    return parse_headers(buf, buf_end, headers, num_headers, max_headers, ret);
 }
 
-int phr_parse_request(const char* buf_start, size_t len, const char** method,
-		      size_t* method_len, const char** path, size_t* path_len,
-		      int* minor_version, struct phr_header* headers,
-		      size_t* num_headers, size_t last_len)
+int phr_parse_response(const char *buf_start, size_t len, int *minor_version, int *status, const char **msg, size_t *msg_len,
+                       struct phr_header *headers, size_t *num_headers, size_t last_len)
 {
-  const char * buf = buf_start, * buf_end = buf_start + len;
-  size_t max_headers = *num_headers;
-  int r;
-  
-  *method = NULL;
-  *method_len = 0;
-  *path = NULL;
-  *path_len = 0;
-  *minor_version = -1;
-  *num_headers = 0;
-  
-  /* if last_len != 0, check if the request is complete (a fast countermeasure
-     againt slowloris */
-  if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
-    return r;
-  }
-  
-  if ((buf = parse_request(buf, buf_end, method, method_len, path, path_len,
-			   minor_version, headers, num_headers, max_headers,
-			   &r))
-      == NULL) {
-    return r;
-  }
-  
-  return buf - buf_start;
+    const char *buf = buf_start, *buf_end = buf + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *minor_version = -1;
+    *status = 0;
+    *msg = NULL;
+    *msg_len = 0;
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the response is complete (a fast countermeasure
+       against slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
+    }
+
+    if ((buf = parse_response(buf, buf_end, minor_version, status, msg, msg_len, headers, num_headers, max_headers, &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
 }
 
-static const char* parse_response(const char* buf, const char* buf_end,
-				  int* minor_version, int* status,
-				  const char** msg, size_t* msg_len,
-				  struct phr_header* headers,
-				  size_t* num_headers, size_t max_headers,
-				  int* ret)
+int phr_parse_headers(const char *buf_start, size_t len, struct phr_header *headers, size_t *num_headers, size_t last_len)
 {
-  /* parse "HTTP/1.x" */
-  if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
-    return NULL;
-  }
-  /* skip space */
-  if (*buf++ != ' ') {
-    *ret = -1;
-    return NULL;
-  }
-  /* parse status code */
-  if ((buf = parse_int(buf, buf_end, status, ret)) == NULL) {
-    return NULL;
-  }
-  /* skip space */
-  if (*buf++ != ' ') {
-    *ret = -1;
-    return NULL;
-  }
-  /* get message */
-  if ((buf = get_token_to_eol(buf, buf_end, msg, msg_len, ret)) == NULL) {
-    return NULL;
-  }
-  
-  return parse_headers(buf, buf_end, headers, num_headers, max_headers, ret);
+    const char *buf = buf_start, *buf_end = buf + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the response is complete (a fast countermeasure
+       against slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
+    }
+
+    if ((buf = parse_headers(buf, buf_end, headers, num_headers, max_headers, &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
 }
 
-int phr_parse_response(const char* buf_start, size_t len, int* minor_version,
-		       int* status, const char** msg, size_t* msg_len,
-		       struct phr_header* headers, size_t* num_headers,
-		       size_t last_len)
+enum {
+    CHUNKED_IN_CHUNK_SIZE,
+    CHUNKED_IN_CHUNK_EXT,
+    CHUNKED_IN_CHUNK_DATA,
+    CHUNKED_IN_CHUNK_CRLF,
+    CHUNKED_IN_TRAILERS_LINE_HEAD,
+    CHUNKED_IN_TRAILERS_LINE_MIDDLE
+};
+
+static int decode_hex(int ch)
 {
-  const char * buf = buf_start, * buf_end = buf + len;
-  size_t max_headers = *num_headers;
-  int r;
-  
-  *minor_version = -1;
-  *status = 0;
-  *msg = NULL;
-  *msg_len = 0;
-  *num_headers = 0;
-  
-  /* if last_len != 0, check if the response is complete (a fast countermeasure
-     against slowloris */
-  if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
-    return r;
-  }
-  
-  if ((buf = parse_response(buf, buf_end, minor_version, status, msg, msg_len,
-			    headers, num_headers, max_headers, &r))
-      == NULL) {
-    return r;
-  }
-  
-  return buf - buf_start;
+    if ('0' <= ch && ch <= '9') {
+        return ch - '0';
+    } else if ('A' <= ch && ch <= 'F') {
+        return ch - 'A' + 0xa;
+    } else if ('a' <= ch && ch <= 'f') {
+        return ch - 'a' + 0xa;
+    } else {
+        return -1;
+    }
+}
+
+ssize_t phr_decode_chunked(struct phr_chunked_decoder *decoder, char *buf, size_t *_bufsz)
+{
+    size_t dst = 0, src = 0, bufsz = *_bufsz;
+    ssize_t ret = -2; /* incomplete */
+
+    decoder->_total_read += bufsz;
+
+    while (1) {
+        switch (decoder->_state) {
+        case CHUNKED_IN_CHUNK_SIZE:
+            for (;; ++src) {
+                int v;
+                if (src == bufsz)
+                    goto Exit;
+                if ((v = decode_hex(buf[src])) == -1) {
+                    if (decoder->_hex_count == 0) {
+                        ret = -1;
+                        goto Exit;
+                    }
+                    /* the only characters that may appear after the chunk size are BWS, semicolon, or CRLF */
+                    switch (buf[src]) {
+                    case ' ':
+                    case '\011':
+                    case ';':
+                    case '\012':
+                    case '\015':
+                        break;
+                    default:
+                        ret = -1;
+                        goto Exit;
+                    }
+                    break;
+                }
+                if (decoder->_hex_count == sizeof(size_t) * 2) {
+                    ret = -1;
+                    goto Exit;
+                }
+                decoder->bytes_left_in_chunk = decoder->bytes_left_in_chunk * 16 + v;
+                ++decoder->_hex_count;
+            }
+            decoder->_hex_count = 0;
+            decoder->_state = CHUNKED_IN_CHUNK_EXT;
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_EXT:
+            /* RFC 7230 A.2 "Line folding in chunk extensions is disallowed" */
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] == '\012')
+                    break;
+            }
+            ++src;
+            if (decoder->bytes_left_in_chunk == 0) {
+                if (decoder->consume_trailer) {
+                    decoder->_state = CHUNKED_IN_TRAILERS_LINE_HEAD;
+                    break;
+                } else {
+                    goto Complete;
+                }
+            }
+            decoder->_state = CHUNKED_IN_CHUNK_DATA;
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_DATA: {
+            size_t avail = bufsz - src;
+            if (avail < decoder->bytes_left_in_chunk) {
+                if (dst != src)
+                    memmove(buf + dst, buf + src, avail);
+                src += avail;
+                dst += avail;
+                decoder->bytes_left_in_chunk -= avail;
+                goto Exit;
+            }
+            if (dst != src)
+                memmove(buf + dst, buf + src, decoder->bytes_left_in_chunk);
+            src += decoder->bytes_left_in_chunk;
+            dst += decoder->bytes_left_in_chunk;
+            decoder->bytes_left_in_chunk = 0;
+            decoder->_state = CHUNKED_IN_CHUNK_CRLF;
+        }
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_CRLF:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] != '\015')
+                    break;
+            }
+            if (buf[src] != '\012') {
+                ret = -1;
+                goto Exit;
+            }
+            ++src;
+            decoder->_state = CHUNKED_IN_CHUNK_SIZE;
+            break;
+        case CHUNKED_IN_TRAILERS_LINE_HEAD:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] != '\015')
+                    break;
+            }
+            if (buf[src++] == '\012')
+                goto Complete;
+            decoder->_state = CHUNKED_IN_TRAILERS_LINE_MIDDLE;
+        /* fallthru */
+        case CHUNKED_IN_TRAILERS_LINE_MIDDLE:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] == '\012')
+                    break;
+            }
+            ++src;
+            decoder->_state = CHUNKED_IN_TRAILERS_LINE_HEAD;
+            break;
+        default:
+            assert(!"decoder is corrupt");
+        }
+    }
+
+Complete:
+    ret = bufsz - src;
+Exit:
+    if (dst != src)
+        memmove(buf + dst, buf + src, bufsz - src);
+    *_bufsz = dst;
+    /* if incomplete but the overhead of the chunked encoding is >=100KB and >80%, signal an error */
+    if (ret == -2) {
+        decoder->_total_overhead += bufsz - dst;
+        if (decoder->_total_overhead >= 100 * 1024 && decoder->_total_read - decoder->_total_overhead < decoder->_total_read / 4)
+            ret = -1;
+    }
+    return ret;
+}
+
+int phr_decode_chunked_is_in_data(struct phr_chunked_decoder *decoder)
+{
+    return decoder->_state == CHUNKED_IN_CHUNK_DATA;
 }
 
 #undef CHECK_EOF

--- a/picohttpparser/picohttpparser.h
+++ b/picohttpparser/picohttpparser.h
@@ -1,7 +1,38 @@
+/*
+ * Copyright (c) 2009-2014 Kazuho Oku, Tokuhiro Matsuno, Daisuke Murase,
+ *                         Shigeo Mitsunari
+ *
+ * The software is licensed under either the MIT License (below) or the Perl
+ * license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
 #ifndef picohttpparser_h
 #define picohttpparser_h
 
-/* $Id: e8df3d19ac99b0e989e41f8281fd710fa94d17d4 $ */
+#include <stdint.h>
+#include <sys/types.h>
+
+#ifdef _MSC_VER
+#define ssize_t intptr_t
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -10,25 +41,47 @@ extern "C" {
 /* contains name and value of a header (name == NULL if is a continuing line
  * of a multiline header */
 struct phr_header {
-  const char* name;
-  size_t name_len;
-  const char* value;
-  size_t value_len;
+    const char *name;
+    size_t name_len;
+    const char *value;
+    size_t value_len;
 };
 
-/* returns number of bytes cosumed if successful, -2 if request is partial,
+/* returns number of bytes consumed if successful, -2 if request is partial,
  * -1 if failed */
-int phr_parse_request(const char* buf, size_t len, const char** method,
-		      size_t* method_len, const char** path,
-		      size_t* path_len, int* minor_version,
-		      struct phr_header* headers, size_t* num_headers,
-		      size_t last_len);
+int phr_parse_request(const char *buf, size_t len, const char **method, size_t *method_len, const char **path, size_t *path_len,
+                      int *minor_version, struct phr_header *headers, size_t *num_headers, size_t last_len);
 
 /* ditto */
-int phr_parse_response(const char* _buf, size_t len, int *minor_version,
-              int *status, const char **msg, size_t *msg_len,
-              struct phr_header* headers, size_t* num_headers,
-              size_t last_len);
+int phr_parse_response(const char *_buf, size_t len, int *minor_version, int *status, const char **msg, size_t *msg_len,
+                       struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+/* ditto */
+int phr_parse_headers(const char *buf, size_t len, struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+/* should be zero-filled before start */
+struct phr_chunked_decoder {
+    size_t bytes_left_in_chunk; /* number of bytes left in current chunk */
+    char consume_trailer;       /* if trailing headers should be consumed */
+    char _hex_count;
+    char _state;
+    uint64_t _total_read;
+    uint64_t _total_overhead;
+};
+
+/* the function rewrites the buffer given as (buf, bufsz) removing the chunked-
+ * encoding headers.  When the function returns without an error, bufsz is
+ * updated to the length of the decoded data available.  Applications should
+ * repeatedly call the function while it returns -2 (incomplete) every time
+ * supplying newly arrived data.  If the end of the chunked-encoded data is
+ * found, the function returns a non-negative number indicating the number of
+ * octets left undecoded, that starts from the offset returned by `*bufsz`.
+ * Returns -1 on error.
+ */
+ssize_t phr_decode_chunked(struct phr_chunked_decoder *decoder, char *buf, size_t *bufsz);
+
+/* returns if the chunked decoder is in middle of chunked data */
+int phr_decode_chunked_is_in_data(struct phr_chunked_decoder *decoder);
 
 #ifdef __cplusplus
 }

--- a/picohttpparser/test.c
+++ b/picohttpparser/test.c
@@ -1,101 +1,529 @@
+/* use `make test` to run the test */
+/*
+ * Copyright (c) 2009-2014 Kazuho Oku, Tokuhiro Matsuno, Daisuke Murase,
+ *                         Shigeo Mitsunari
+ *
+ * The software is licensed under either the MIT License (below) or the Perl
+ * license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "picotest/picotest.h"
 #include "picohttpparser.h"
 
-void tests(int num)
+static int bufis(const char *s, size_t l, const char *t)
 {
-  printf("1..%d\n", num);
+    return strlen(t) == l && memcmp(s, t, l) == 0;
 }
 
-void ok(int ok, const char* msg)
+static char *inputbuf; /* point to the end of the buffer */
+
+static void test_request(void)
 {
-  static int testnum = 0;
-  printf("%s %d - %s\n", ok ? "ok" : "not ok", ++testnum, msg);
+    const char *method;
+    size_t method_len;
+    const char *path;
+    size_t path_len;
+    int minor_version;
+    struct phr_header headers[4];
+    size_t num_headers;
+
+#define PARSE(s, last_len, exp, comment)                                                                                           \
+    do {                                                                                                                           \
+        size_t slen = sizeof(s) - 1;                                                                                               \
+        note(comment);                                                                                                             \
+        num_headers = sizeof(headers) / sizeof(headers[0]);                                                                        \
+        memcpy(inputbuf - slen, s, slen);                                                                                          \
+        ok(phr_parse_request(inputbuf - slen, slen, &method, &method_len, &path, &path_len, &minor_version, headers, &num_headers, \
+                             last_len) == (exp == 0 ? (int)slen : exp));                                                           \
+    } while (0)
+
+    PARSE("GET / HTTP/1.0\r\n\r\n", 0, 0, "simple");
+    ok(num_headers == 0);
+    ok(bufis(method, method_len, "GET"));
+    ok(bufis(path, path_len, "/"));
+    ok(minor_version == 0);
+
+    PARSE("GET / HTTP/1.0\r\n\r", 0, -2, "partial");
+
+    PARSE("GET /hoge HTTP/1.1\r\nHost: example.com\r\nCookie: \r\n\r\n", 0, 0, "parse headers");
+    ok(num_headers == 2);
+    ok(bufis(method, method_len, "GET"));
+    ok(bufis(path, path_len, "/hoge"));
+    ok(minor_version == 1);
+    ok(bufis(headers[0].name, headers[0].name_len, "Host"));
+    ok(bufis(headers[0].value, headers[0].value_len, "example.com"));
+    ok(bufis(headers[1].name, headers[1].name_len, "Cookie"));
+    ok(bufis(headers[1].value, headers[1].value_len, ""));
+
+    PARSE("GET /hoge HTTP/1.1\r\nHost: example.com\r\nUser-Agent: \343\201\262\343/1.0\r\n\r\n", 0, 0, "multibyte included");
+    ok(num_headers == 2);
+    ok(bufis(method, method_len, "GET"));
+    ok(bufis(path, path_len, "/hoge"));
+    ok(minor_version == 1);
+    ok(bufis(headers[0].name, headers[0].name_len, "Host"));
+    ok(bufis(headers[0].value, headers[0].value_len, "example.com"));
+    ok(bufis(headers[1].name, headers[1].name_len, "User-Agent"));
+    ok(bufis(headers[1].value, headers[1].value_len, "\343\201\262\343/1.0"));
+
+    PARSE("GET / HTTP/1.0\r\nfoo: \r\nfoo: b\r\n  \tc\r\n\r\n", 0, 0, "parse multiline");
+    ok(num_headers == 3);
+    ok(bufis(method, method_len, "GET"));
+    ok(bufis(path, path_len, "/"));
+    ok(minor_version == 0);
+    ok(bufis(headers[0].name, headers[0].name_len, "foo"));
+    ok(bufis(headers[0].value, headers[0].value_len, ""));
+    ok(bufis(headers[1].name, headers[1].name_len, "foo"));
+    ok(bufis(headers[1].value, headers[1].value_len, "b"));
+    ok(headers[2].name == NULL);
+    ok(bufis(headers[2].value, headers[2].value_len, "  \tc"));
+
+    PARSE("GET / HTTP/1.0\r\nfoo : ab\r\n\r\n", 0, -1, "parse header name with trailing space");
+
+    PARSE("GET", 0, -2, "incomplete 1");
+    ok(method == NULL);
+    PARSE("GET ", 0, -2, "incomplete 2");
+    ok(bufis(method, method_len, "GET"));
+    PARSE("GET /", 0, -2, "incomplete 3");
+    ok(path == NULL);
+    PARSE("GET / ", 0, -2, "incomplete 4");
+    ok(bufis(path, path_len, "/"));
+    PARSE("GET / H", 0, -2, "incomplete 5");
+    PARSE("GET / HTTP/1.", 0, -2, "incomplete 6");
+    PARSE("GET / HTTP/1.0", 0, -2, "incomplete 7");
+    ok(minor_version == -1);
+    PARSE("GET / HTTP/1.0\r", 0, -2, "incomplete 8");
+    ok(minor_version == 0);
+
+    PARSE("GET /hoge HTTP/1.0\r\n\r", strlen("GET /hoge HTTP/1.0\r\n\r") - 1, -2, "slowloris (incomplete)");
+    PARSE("GET /hoge HTTP/1.0\r\n\r\n", strlen("GET /hoge HTTP/1.0\r\n\r\n") - 1, 0, "slowloris (complete)");
+
+    PARSE(" / HTTP/1.0\r\n\r\n", 0, -1, "empty method");
+    PARSE("GET  HTTP/1.0\r\n\r\n", 0, -1, "empty request-target");
+
+    PARSE("GET / HTTP/1.0\r\n:a\r\n\r\n", 0, -1, "empty header name");
+    PARSE("GET / HTTP/1.0\r\n :a\r\n\r\n", 0, -1, "header name (space only)");
+
+    PARSE("G\0T / HTTP/1.0\r\n\r\n", 0, -1, "NUL in method");
+    PARSE("G\tT / HTTP/1.0\r\n\r\n", 0, -1, "tab in method");
+    PARSE(":GET / HTTP/1.0\r\n\r\n", 0, -1, "invalid method");
+    PARSE("GET /\x7fhello HTTP/1.0\r\n\r\n", 0, -1, "DEL in uri-path");
+    PARSE("GET / HTTP/1.0\r\na\0b: c\r\n\r\n", 0, -1, "NUL in header name");
+    PARSE("GET / HTTP/1.0\r\nab: c\0d\r\n\r\n", 0, -1, "NUL in header value");
+    PARSE("GET / HTTP/1.0\r\na\033b: c\r\n\r\n", 0, -1, "CTL in header name");
+    PARSE("GET / HTTP/1.0\r\nab: c\033\r\n\r\n", 0, -1, "CTL in header value");
+    PARSE("GET / HTTP/1.0\r\n/: 1\r\n\r\n", 0, -1, "invalid char in header value");
+    PARSE("GET /\xa0 HTTP/1.0\r\nh: c\xa2y\r\n\r\n", 0, 0, "accept MSB chars");
+    ok(num_headers == 1);
+    ok(bufis(method, method_len, "GET"));
+    ok(bufis(path, path_len, "/\xa0"));
+    ok(minor_version == 0);
+    ok(bufis(headers[0].name, headers[0].name_len, "h"));
+    ok(bufis(headers[0].value, headers[0].value_len, "c\xa2y"));
+
+    PARSE("GET / HTTP/1.0\r\n\x7c\x7e: 1\r\n\r\n", 0, 0, "accept |~ (though forbidden by SSE)");
+    ok(num_headers == 1);
+    ok(bufis(headers[0].name, headers[0].name_len, "\x7c\x7e"));
+    ok(bufis(headers[0].value, headers[0].value_len, "1"));
+
+    PARSE("GET / HTTP/1.0\r\n\x7b: 1\r\n\r\n", 0, -1, "disallow {");
+
+    PARSE("GET / HTTP/1.0\r\nfoo: a \t \r\n\r\n", 0, 0, "exclude leading and trailing spaces in header value");
+    ok(bufis(headers[0].value, headers[0].value_len, "a"));
+
+    PARSE("GET   /   HTTP/1.0\r\n\r\n", 0, 0, "accept multiple spaces between tokens");
+
+#undef PARSE
 }
 
-int strrcmp(const char* s, size_t l, const char* t)
+static void test_response(void)
 {
-  return strlen(t) == l && memcmp(s, t, l) == 0;
+    int minor_version;
+    int status;
+    const char *msg;
+    size_t msg_len;
+    struct phr_header headers[4];
+    size_t num_headers;
+
+#define PARSE(s, last_len, exp, comment)                                                                                           \
+    do {                                                                                                                           \
+        size_t slen = sizeof(s) - 1;                                                                                               \
+        note(comment);                                                                                                             \
+        num_headers = sizeof(headers) / sizeof(headers[0]);                                                                        \
+        memcpy(inputbuf - slen, s, slen);                                                                                          \
+        ok(phr_parse_response(inputbuf - slen, slen, &minor_version, &status, &msg, &msg_len, headers, &num_headers, last_len) ==  \
+           (exp == 0 ? (int)slen : exp));                                                                                          \
+    } while (0)
+
+    PARSE("HTTP/1.0 200 OK\r\n\r\n", 0, 0, "simple");
+    ok(num_headers == 0);
+    ok(status == 200);
+    ok(minor_version == 0);
+    ok(bufis(msg, msg_len, "OK"));
+
+    PARSE("HTTP/1.0 200 OK\r\n\r", 0, -2, "partial");
+
+    PARSE("HTTP/1.1 200 OK\r\nHost: example.com\r\nCookie: \r\n\r\n", 0, 0, "parse headers");
+    ok(num_headers == 2);
+    ok(minor_version == 1);
+    ok(status == 200);
+    ok(bufis(msg, msg_len, "OK"));
+    ok(bufis(headers[0].name, headers[0].name_len, "Host"));
+    ok(bufis(headers[0].value, headers[0].value_len, "example.com"));
+    ok(bufis(headers[1].name, headers[1].name_len, "Cookie"));
+    ok(bufis(headers[1].value, headers[1].value_len, ""));
+
+    PARSE("HTTP/1.0 200 OK\r\nfoo: \r\nfoo: b\r\n  \tc\r\n\r\n", 0, 0, "parse multiline");
+    ok(num_headers == 3);
+    ok(minor_version == 0);
+    ok(status == 200);
+    ok(bufis(msg, msg_len, "OK"));
+    ok(bufis(headers[0].name, headers[0].name_len, "foo"));
+    ok(bufis(headers[0].value, headers[0].value_len, ""));
+    ok(bufis(headers[1].name, headers[1].name_len, "foo"));
+    ok(bufis(headers[1].value, headers[1].value_len, "b"));
+    ok(headers[2].name == NULL);
+    ok(bufis(headers[2].value, headers[2].value_len, "  \tc"));
+
+    PARSE("HTTP/1.0 500 Internal Server Error\r\n\r\n", 0, 0, "internal server error");
+    ok(num_headers == 0);
+    ok(minor_version == 0);
+    ok(status == 500);
+    ok(bufis(msg, msg_len, "Internal Server Error"));
+    ok(msg_len == sizeof("Internal Server Error") - 1);
+
+    PARSE("H", 0, -2, "incomplete 1");
+    PARSE("HTTP/1.", 0, -2, "incomplete 2");
+    PARSE("HTTP/1.1", 0, -2, "incomplete 3");
+    ok(minor_version == -1);
+    PARSE("HTTP/1.1 ", 0, -2, "incomplete 4");
+    ok(minor_version == 1);
+    PARSE("HTTP/1.1 2", 0, -2, "incomplete 5");
+    PARSE("HTTP/1.1 200", 0, -2, "incomplete 6");
+    ok(status == 0);
+    PARSE("HTTP/1.1 200 ", 0, -2, "incomplete 7");
+    ok(status == 200);
+    PARSE("HTTP/1.1 200 O", 0, -2, "incomplete 8");
+    PARSE("HTTP/1.1 200 OK\r", 0, -2, "incomplete 9");
+    ok(msg == NULL);
+    PARSE("HTTP/1.1 200 OK\r\n", 0, -2, "incomplete 10");
+    ok(bufis(msg, msg_len, "OK"));
+    PARSE("HTTP/1.1 200 OK\n", 0, -2, "incomplete 11");
+    ok(bufis(msg, msg_len, "OK"));
+
+    PARSE("HTTP/1.1 200 OK\r\nA: 1\r", 0, -2, "incomplete 11");
+    ok(num_headers == 0);
+    PARSE("HTTP/1.1 200 OK\r\nA: 1\r\n", 0, -2, "incomplete 12");
+    ok(num_headers == 1);
+    ok(bufis(headers[0].name, headers[0].name_len, "A"));
+    ok(bufis(headers[0].value, headers[0].value_len, "1"));
+
+    PARSE("HTTP/1.0 200 OK\r\n\r", strlen("HTTP/1.0 200 OK\r\n\r") - 1, -2, "slowloris (incomplete)");
+    PARSE("HTTP/1.0 200 OK\r\n\r\n", strlen("HTTP/1.0 200 OK\r\n\r\n") - 1, 0, "slowloris (complete)");
+
+    PARSE("HTTP/1. 200 OK\r\n\r\n", 0, -1, "invalid http version");
+    PARSE("HTTP/1.2z 200 OK\r\n\r\n", 0, -1, "invalid http version 2");
+    PARSE("HTTP/1.1  OK\r\n\r\n", 0, -1, "no status code");
+
+    PARSE("HTTP/1.1 200\r\n\r\n", 0, 0, "accept missing trailing whitespace in status-line");
+    ok(bufis(msg, msg_len, ""));
+    PARSE("HTTP/1.1 200X\r\n\r\n", 0, -1, "garbage after status 1");
+    PARSE("HTTP/1.1 200X \r\n\r\n", 0, -1, "garbage after status 2");
+    PARSE("HTTP/1.1 200X OK\r\n\r\n", 0, -1, "garbage after status 3");
+
+    PARSE("HTTP/1.1 200 OK\r\nbar: \t b\t \t\r\n\r\n", 0, 0, "exclude leading and trailing spaces in header value");
+    ok(bufis(headers[0].value, headers[0].value_len, "b"));
+
+    PARSE("HTTP/1.1   200   OK\r\n\r\n", 0, 0, "accept multiple spaces between tokens");
+
+#undef PARSE
+}
+
+static void test_headers(void)
+{
+    /* only test the interface; the core parser is tested by the tests above */
+
+    struct phr_header headers[4];
+    size_t num_headers;
+
+#define PARSE(s, last_len, exp, comment)                                                                                           \
+    do {                                                                                                                           \
+        note(comment);                                                                                                             \
+        num_headers = sizeof(headers) / sizeof(headers[0]);                                                                        \
+        ok(phr_parse_headers(s, strlen(s), headers, &num_headers, last_len) == (exp == 0 ? (int)strlen(s) : exp));                 \
+    } while (0)
+
+    PARSE("Host: example.com\r\nCookie: \r\n\r\n", 0, 0, "simple");
+    ok(num_headers == 2);
+    ok(bufis(headers[0].name, headers[0].name_len, "Host"));
+    ok(bufis(headers[0].value, headers[0].value_len, "example.com"));
+    ok(bufis(headers[1].name, headers[1].name_len, "Cookie"));
+    ok(bufis(headers[1].value, headers[1].value_len, ""));
+
+    PARSE("Host: example.com\r\nCookie: \r\n\r\n", 1, 0, "slowloris");
+    ok(num_headers == 2);
+    ok(bufis(headers[0].name, headers[0].name_len, "Host"));
+    ok(bufis(headers[0].value, headers[0].value_len, "example.com"));
+    ok(bufis(headers[1].name, headers[1].name_len, "Cookie"));
+    ok(bufis(headers[1].value, headers[1].value_len, ""));
+
+    PARSE("Host: example.com\r\nCookie: \r\n\r", 0, -2, "partial");
+
+    PARSE("Host: e\7fample.com\r\nCookie: \r\n\r", 0, -1, "error");
+
+#undef PARSE
+}
+
+static void test_chunked_at_once(int line, int consume_trailer, const char *encoded, const char *decoded, ssize_t expected)
+{
+    struct phr_chunked_decoder dec = {0};
+    char *buf;
+    size_t bufsz;
+    ssize_t ret;
+
+    dec.consume_trailer = consume_trailer;
+
+    note("testing at-once, source at line %d", line);
+
+    buf = strdup(encoded);
+    bufsz = strlen(buf);
+
+    ret = phr_decode_chunked(&dec, buf, &bufsz);
+
+    ok(ret == expected);
+    ok(bufsz == strlen(decoded));
+    ok(bufis(buf, bufsz, decoded));
+    if (expected >= 0) {
+        if (ret == expected)
+            ok(bufis(buf + bufsz, ret, encoded + strlen(encoded) - ret));
+        else
+            ok(0);
+    }
+
+    free(buf);
+}
+
+static void test_chunked_per_byte(int line, int consume_trailer, const char *encoded, const char *decoded, ssize_t expected)
+{
+    struct phr_chunked_decoder dec = {0};
+    char *buf = malloc(strlen(encoded) + 1);
+    size_t bytes_to_consume = strlen(encoded) - (expected >= 0 ? expected : 0), bytes_ready = 0, bufsz, i;
+    ssize_t ret;
+
+    dec.consume_trailer = consume_trailer;
+
+    note("testing per-byte, source at line %d", line);
+
+    for (i = 0; i < bytes_to_consume - 1; ++i) {
+        buf[bytes_ready] = encoded[i];
+        bufsz = 1;
+        ret = phr_decode_chunked(&dec, buf + bytes_ready, &bufsz);
+        if (ret != -2) {
+            ok(0);
+            goto cleanup;
+        }
+        bytes_ready += bufsz;
+    }
+    strcpy(buf + bytes_ready, encoded + bytes_to_consume - 1);
+    bufsz = strlen(buf + bytes_ready);
+    ret = phr_decode_chunked(&dec, buf + bytes_ready, &bufsz);
+    ok(ret == expected);
+    bytes_ready += bufsz;
+    ok(bytes_ready == strlen(decoded));
+    ok(bufis(buf, bytes_ready, decoded));
+    if (expected >= 0) {
+        if (ret == expected)
+            ok(bufis(buf + bytes_ready, expected, encoded + bytes_to_consume));
+        else
+            ok(0);
+    }
+
+cleanup:
+    free(buf);
+}
+
+static void test_chunked_failure(int line, const char *encoded, ssize_t expected)
+{
+    struct phr_chunked_decoder dec = {0};
+    char *buf = strdup(encoded);
+    size_t bufsz, i;
+    ssize_t ret;
+
+    note("testing failure at-once, source at line %d", line);
+    bufsz = strlen(buf);
+    ret = phr_decode_chunked(&dec, buf, &bufsz);
+    ok(ret == expected);
+
+    note("testing failure per-byte, source at line %d", line);
+    memset(&dec, 0, sizeof(dec));
+    for (i = 0; encoded[i] != '\0'; ++i) {
+        buf[0] = encoded[i];
+        bufsz = 1;
+        ret = phr_decode_chunked(&dec, buf, &bufsz);
+        if (ret == -1) {
+            ok(ret == expected);
+            goto cleanup;
+        } else if (ret == -2) {
+            /* continue */
+        } else {
+            ok(0);
+            goto cleanup;
+        }
+    }
+    ok(ret == expected);
+
+cleanup:
+    free(buf);
+}
+
+static void (*chunked_test_runners[])(int, int, const char *, const char *, ssize_t) = {test_chunked_at_once, test_chunked_per_byte,
+                                                                                        NULL};
+
+static void test_chunked(void)
+{
+    size_t i;
+
+    for (i = 0; chunked_test_runners[i] != NULL; ++i) {
+        chunked_test_runners[i](__LINE__, 0, "b\r\nhello world\r\n0\r\n", "hello world", 0);
+        chunked_test_runners[i](__LINE__, 0, "6\r\nhello \r\n5\r\nworld\r\n0\r\n", "hello world", 0);
+        chunked_test_runners[i](__LINE__, 0, "6;comment=hi\r\nhello \r\n5\r\nworld\r\n0\r\n", "hello world", 0);
+        chunked_test_runners[i](__LINE__, 0, "6 ; comment\r\nhello \r\n5\r\nworld\r\n0\r\n", "hello world", 0);
+        chunked_test_runners[i](__LINE__, 0, "6\r\nhello \r\n5\r\nworld\r\n0\r\na: b\r\nc: d\r\n\r\n", "hello world",
+                                sizeof("a: b\r\nc: d\r\n\r\n") - 1);
+        chunked_test_runners[i](__LINE__, 0, "b\r\nhello world\r\n0\r\n", "hello world", 0);
+    }
+
+    note("failures");
+    test_chunked_failure(__LINE__, "z\r\nabcdefg", -1);
+    if (sizeof(size_t) == 8) {
+        test_chunked_failure(__LINE__, "6\r\nhello \r\nffffffffffffffff\r\nabcdefg", -2);
+        test_chunked_failure(__LINE__, "6\r\nhello \r\nfffffffffffffffff\r\nabcdefg", -1);
+    }
+    test_chunked_failure(__LINE__, "1x\r\na\r\n0\r\n", -1);
+}
+
+static void test_chunked_consume_trailer(void)
+{
+    size_t i;
+
+    for (i = 0; chunked_test_runners[i] != NULL; ++i) {
+        chunked_test_runners[i](__LINE__, 1, "b\r\nhello world\r\n0\r\n", "hello world", -2);
+        chunked_test_runners[i](__LINE__, 1, "6\r\nhello \r\n5\r\nworld\r\n0\r\n", "hello world", -2);
+        chunked_test_runners[i](__LINE__, 1, "6;comment=hi\r\nhello \r\n5\r\nworld\r\n0\r\n", "hello world", -2);
+        chunked_test_runners[i](__LINE__, 1, "b\r\nhello world\r\n0\r\n\r\n", "hello world", 0);
+        chunked_test_runners[i](__LINE__, 1, "b\nhello world\n0\n\n", "hello world", 0);
+        chunked_test_runners[i](__LINE__, 1, "6\r\nhello \r\n5\r\nworld\r\n0\r\na: b\r\nc: d\r\n\r\n", "hello world", 0);
+    }
+}
+
+static void test_chunked_leftdata(void)
+{
+#define NEXT_REQ "GET / HTTP/1.1\r\n\r\n"
+
+    struct phr_chunked_decoder dec = {0};
+    dec.consume_trailer = 1;
+    char buf[] = "5\r\nabcde\r\n0\r\n\r\n" NEXT_REQ;
+    size_t bufsz = sizeof(buf) - 1;
+
+    ssize_t ret = phr_decode_chunked(&dec, buf, &bufsz);
+    ok(ret >= 0);
+    ok(bufsz == 5);
+    ok(memcmp(buf, "abcde", 5) == 0);
+    ok(ret == sizeof(NEXT_REQ) - 1);
+    ok(memcmp(buf + bufsz, NEXT_REQ, sizeof(NEXT_REQ) - 1) == 0);
+
+#undef NEXT_REQ
+}
+
+static ssize_t do_test_chunked_overhead(size_t chunk_len, size_t chunk_count, const char *extra)
+{
+    struct phr_chunked_decoder dec = {0};
+    char buf[1024];
+    size_t bufsz;
+    ssize_t ret;
+
+    for (size_t i = 0; i < chunk_count; ++i) {
+        /* build and feed the chunk header */
+        bufsz = (size_t)sprintf(buf, "%zx%s\r\n", chunk_len, extra);
+        if ((ret = phr_decode_chunked(&dec, buf, &bufsz)) != -2)
+            goto Exit;
+        assert(bufsz == 0);
+        /* build and feed the chunk boby */
+        memset(buf, 'A', chunk_len);
+        bufsz = chunk_len;
+        if ((ret = phr_decode_chunked(&dec, buf, &bufsz)) != -2)
+            goto Exit;
+        assert(bufsz == chunk_len);
+        /* build and feed the chunk end (CRLF) */
+        strcpy(buf, "\r\n");
+        bufsz = 2;
+        if ((ret = phr_decode_chunked(&dec, buf, &bufsz)) != -2)
+            goto Exit;
+        assert(bufsz == 0);
+    }
+
+    /* build and feed the end chunk */
+    strcpy(buf, "0\r\n\r\n");
+    bufsz = 5;
+    ret = phr_decode_chunked(&dec, buf, &bufsz);
+    assert(bufsz == 0);
+
+Exit:
+    return ret;
+}
+
+static void test_chunked_overhead(void)
+{
+    ok(do_test_chunked_overhead(100, 10000, "") == 2 /* consume trailer is not set */);
+    ok(do_test_chunked_overhead(10, 100000, "") == 2 /* consume trailer is not set */);
+    ok(do_test_chunked_overhead(1, 1000000, "") == -1);
+
+    ok(do_test_chunked_overhead(10, 100000, "; tiny=1") == 2 /* consume trailer is not set */);
+    ok(do_test_chunked_overhead(10, 100000, "; large=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") == -1);
 }
 
 int main(void)
 {
-  const char* method;
-  size_t method_len;
-  const char* path;
-  size_t path_len;
-  int minor_version;
-  struct phr_header headers[4];
-  size_t num_headers;
-  
-  tests(42);
-  
-#define PARSE(s, last_len, exp, comment)				\
-  num_headers = sizeof(headers) / sizeof(headers[0]);			\
-  ok(phr_parse_request(s, strlen(s), &method, &method_len, &path,	\
-		       &path_len, &minor_version, headers,		\
-		       &num_headers, last_len)				\
-    == (exp == 0 ? strlen(s) : exp),					\
-    comment)
-  
-  PARSE("GET / HTTP/1.0\r\n\r\n", 0, 0, "simple");
-  ok(num_headers == 0, "# of headers");
-  ok(strrcmp(method, method_len, "GET"), "method");
-  ok(strrcmp(path, path_len, "/"), "path");
-  ok(minor_version == 0, "minor version");
-  
-  PARSE("GET / HTTP/1.0\r\n\r", 0, -2, "partial");
-  
-  PARSE("GET /hoge HTTP/1.1\r\nHost: example.com\r\nCookie: \r\n\r\n", 0, 0,
-	"parse headers");
-  ok(num_headers == 2, "# of headers");
-  ok(strrcmp(method, method_len, "GET"), "method");
-  ok(strrcmp(path, path_len, "/hoge"), "path");
-  ok(minor_version == 1, "minor version");
-  ok(strrcmp(headers[0].name, headers[0].name_len, "Host"), "host");
-  ok(strrcmp(headers[0].value, headers[0].value_len, "example.com"),
-     "host value");
-  ok(strrcmp(headers[1].name, headers[1].name_len, "Cookie"), "cookie");
-  ok(strrcmp(headers[1].value, headers[1].value_len, ""), "cookie value");
-  
-  PARSE("GET / HTTP/1.0\r\nfoo: \r\nfoo: b\r\n  \tc\r\n\r\n", 0, 0,
-	"parse multiline");
-  ok(num_headers == 3, "# of headers");
-  ok(strrcmp(method, method_len, "GET"), "method");
-  ok(strrcmp(path, path_len, "/"), "path");
-  ok(minor_version == 0, "minor version");
-  ok(strrcmp(headers[0].name, headers[0].name_len, "foo"), "header #1 name");
-  ok(strrcmp(headers[0].value, headers[0].value_len, ""), "header #1 value");
-  ok(strrcmp(headers[1].name, headers[1].name_len, "foo"), "header #2 name");
-  ok(strrcmp(headers[1].value, headers[1].value_len, "b"), "header #2 value");
-  ok(headers[2].name == NULL, "header #3");
-  ok(strrcmp(headers[2].value, headers[2].value_len, "  \tc"),
-     "header #3 value");
-  
-  PARSE("GET", 0, -2, "incomplete 1");
-  ok(method == NULL, "method not ready");
-  PARSE("GET ", 0, -2, "incomplete 2");
-  ok(strrcmp(method, method_len, "GET"), "method ready");
-  PARSE("GET /", 0, -2, "incomplete 3");
-  ok(path == NULL, "path not ready");
-  PARSE("GET / ", 0, -2, "incomplete 4");
-  ok(strrcmp(path, path_len, "/"), "path ready");
-  PARSE("GET / H", 0, -2, "incomplete 5");
-  PARSE("GET / HTTP/1.", 0, -2, "incomplete 6");
-  PARSE("GET / HTTP/1.0", 0, -2, "incomplete 7");
-  ok(minor_version == -1, "version not ready");
-  PARSE("GET / HTTP/1.0\r", 0, -2, "incomplete 8");
-  ok(minor_version == 0, "version is ready");
-  
-  PARSE("GET /hoge HTTP/1.0\r\n\r", strlen("GET /hoge HTTP/1.0\r\n\r") - 1,
-	-2, "slowloris (incomplete)");
-  PARSE("GET /hoge HTTP/1.0\r\n\r\n", strlen("GET /hoge HTTP/1.0\r\n\r\n") - 1,
-	0, "slowloris (complete)");
-  
-  PARSE("GET / HTTP/1.0\r\n:a\r\n\r\n", 0, -1, "empty header name");
-  PARSE("GET / HTTP/1.0\r\n :a\r\n\r\n", 0, -1, "header name (space only)");
+    long pagesize = sysconf(_SC_PAGESIZE);
+    assert(pagesize >= 1);
 
-#undef PARSE
-  
-  return 0;
+    inputbuf = mmap(NULL, pagesize * 3, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
+    assert(inputbuf != MAP_FAILED);
+    inputbuf += pagesize * 2;
+    ok(mprotect(inputbuf - pagesize, pagesize, PROT_READ | PROT_WRITE) == 0);
+
+    subtest("request", test_request);
+    subtest("response", test_response);
+    subtest("headers", test_headers);
+    subtest("chunked", test_chunked);
+    subtest("chunked-consume-trailer", test_chunked_consume_trailer);
+    subtest("chunked-leftdata", test_chunked_leftdata);
+    subtest("chunked-overhead", test_chunked_overhead);
+
+    munmap(inputbuf - pagesize * 2, pagesize * 3);
+
+    return done_testing();
 }

--- a/t/03response-error.t
+++ b/t/03response-error.t
@@ -6,7 +6,7 @@ use HTTP::Parser::XS qw/:all/;
 use Data::Dumper;
 
 my $tests = <<'__HEADERS';
-HOGE
+HOGE/1.1 200 OK
 
 ----------
 -1


### PR DESCRIPTION
I will take a stub at re-trying to update picohttpparser, following https://github.com/kazuho/p5-http-parser-xs/pull/21 . Fixes https://github.com/kazuho/p5-http-parser-xs/issues/14 .
In this PR based on https://github.com/kazuho/p5-http-parser-xs/pull/22 to ensure the tests are passing.